### PR TITLE
WIP diff viewer: utilize NEW_TOKEN frames

### DIFF
--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -17,8 +17,8 @@ use crate::{
     cid_generator::{ConnectionIdGenerator, HashedConnectionIdGenerator},
     crypto::{self, HandshakeTokenKey, HmacKey},
     shared::ConnectionId,
-    Duration, RandomConnectionIdGenerator, SystemTime, VarInt, VarIntBoundsExceeded,
-    DEFAULT_SUPPORTED_VERSIONS, MAX_CID_SIZE,
+    Duration, NoneTokenLog, RandomConnectionIdGenerator, SystemTime, TokenLog, VarInt,
+    VarIntBoundsExceeded, DEFAULT_SUPPORTED_VERSIONS, MAX_CID_SIZE,
 };
 
 mod transport;
@@ -197,6 +197,9 @@ pub struct ServerConfig {
     /// Must be set to use TLS 1.3 only.
     pub crypto: Arc<dyn crypto::ServerConfig>,
 
+    /// Configuration for sending and handling validation tokens
+    pub validation_token: ValidationTokenConfig,
+
     /// Used to generate one-time AEAD keys to protect handshake tokens
     pub(crate) token_key: Arc<dyn HandshakeTokenKey>,
 
@@ -234,6 +237,8 @@ impl ServerConfig {
 
             migration: true,
 
+            validation_token: ValidationTokenConfig::default(),
+
             preferred_address_v4: None,
             preferred_address_v6: None,
 
@@ -248,6 +253,15 @@ impl ServerConfig {
     /// Set a custom [`TransportConfig`]
     pub fn transport_config(&mut self, transport: Arc<TransportConfig>) -> &mut Self {
         self.transport = transport;
+        self
+    }
+
+    /// Set a custom [`ValidationTokenConfig`]
+    pub fn validation_token_config(
+        &mut self,
+        validation_token: ValidationTokenConfig,
+    ) -> &mut Self {
+        self.validation_token = validation_token;
         self
     }
 
@@ -392,6 +406,7 @@ impl fmt::Debug for ServerConfig {
             // crypto not debug
             // token not debug
             .field("retry_token_lifetime", &self.retry_token_lifetime)
+            .field("validation_token", &self.validation_token)
             .field("migration", &self.migration)
             .field("preferred_address_v4", &self.preferred_address_v4)
             .field("preferred_address_v6", &self.preferred_address_v6)
@@ -402,6 +417,110 @@ impl fmt::Debug for ServerConfig {
                 &self.incoming_buffer_size_total,
             )
             // system_time_clock not debug
+            .finish_non_exhaustive()
+    }
+}
+
+/// Configuration for sending and handling validation tokens in incoming connections
+///
+/// Default values should be suitable for most internet applications.
+///
+/// ## QUIC Tokens
+///
+/// The QUIC protocol defines a concept of "[address validation][1]". Essentially, one side of a
+/// QUIC connection may appear to be receiving QUIC packets from a particular remote UDP address,
+/// but it will only consider that remote address "validated" once it has convincing evidence that
+/// the address is not being [spoofed][2].
+///
+/// Validation is important primarily because of QUIC's "anti-amplification limit." This limit
+/// prevents a QUIC server from sending a client more than three times the number of bytes it has
+/// received from the client on a given address until that address is validated. This is designed
+/// to mitigate the ability of attackers to use QUIC-based servers as reflectors in [amplification
+/// attacks][3].
+///
+/// A path may become validated in several ways. The server is always considered validated by the
+/// client. The client usually begins in an unvalidated state upon first connecting or migrating,
+/// but then becomes validated through various mechanisms that usually take one network round trip.
+/// However, in some cases, a client which has previously attempted to connect to a server may have
+/// been given a one-time use cryptographically secured "token" that it can send in a subsequent
+/// connection attempt to be validated immediately.
+///
+/// There are two ways these tokens can originate:
+///
+/// - If the server responds to an incoming connection with `retry`, a "retry token" is minted and
+///   sent to the client, which the client immediately uses to attempt to connect again. Retry
+///   tokens operate on short timescales, such as 15 seconds.
+/// - If a client's path within an active connection is validated, the server may send the client
+///   one or more "validation tokens," which the client may store for use in later connections to
+///   the same server. Validation tokens may be valid for much longer lifetimes than retry token.
+///
+/// The usage of validation tokens is most impactful in situations where 0-RTT data is also being
+/// used--in particular, in situations where the server sends the client more than three times more
+/// 0.5-RTT data than it has received 0-RTT data. Since the successful completion of a connection
+/// handshake implicitly causes the client's address to be validated, transmission of 0.5-RTT data
+/// is the main situation where a server might be sending application data to an address that could
+/// be validated by token usage earlier than it would become validated without token usage.
+///
+/// [1]: https://www.rfc-editor.org/rfc/rfc9000.html#section-8
+/// [2]: https://en.wikipedia.org/wiki/IP_address_spoofing
+/// [3]: https://en.wikipedia.org/wiki/Denial-of-service_attack#Amplification
+///
+/// These tokens should not be confused with "stateless reset tokens," which are similarly named
+/// but entirely unrelated.
+#[derive(Clone)]
+pub struct ValidationTokenConfig {
+    pub(crate) lifetime: Duration,
+    pub(crate) log: Arc<dyn TokenLog>,
+    pub(crate) sent: u32,
+}
+
+impl ValidationTokenConfig {
+    /// Duration after an address validation token was issued for which it's considered valid
+    ///
+    /// This refers only to tokens sent in NEW_TOKEN frames, in contrast to retry tokens.
+    ///
+    /// Defaults to 2 weeks.
+    pub fn lifetime(&mut self, value: Duration) -> &mut Self {
+        self.lifetime = value;
+        self
+    }
+
+    /// Set a custom [`TokenLog`]
+    ///
+    /// Defaults to [`NoneTokenLog`], which makes the server ignore all address validation tokens
+    /// (that is, tokens originating from NEW_TOKEN frames--retry tokens may still be accepted).
+    pub fn log(&mut self, log: Arc<dyn TokenLog>) -> &mut Self {
+        self.log = log;
+        self
+    }
+
+    /// Number of address validation tokens sent to a client when its path is validated
+    ///
+    /// This refers only to tokens sent in NEW_TOKEN frames, in contrast to retry tokens.
+    ///
+    /// Defaults to 0.
+    pub fn sent(&mut self, value: u32) -> &mut Self {
+        self.sent = value;
+        self
+    }
+}
+
+impl Default for ValidationTokenConfig {
+    fn default() -> Self {
+        Self {
+            lifetime: Duration::from_secs(2 * 7 * 24 * 60 * 60),
+            log: Arc::new(NoneTokenLog),
+            sent: 0,
+        }
+    }
+}
+
+impl fmt::Debug for ValidationTokenConfig {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("ServerValidationTokenConfig")
+            .field("lifetime", &self.lifetime)
+            // log not debug
+            .field("sent", &self.sent)
             .finish_non_exhaustive()
     }
 }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     coding::BufMutExt,
     config::{ServerConfig, TransportConfig},
     crypto::{self, KeyPair, Keys, PacketKey},
-    frame::{self, Close, Datagram, FrameStruct},
+    frame::{self, Close, Datagram, FrameStruct, NewToken},
     packet::{
         FixedLengthConnectionIdParser, Header, InitialHeader, InitialPacket, LongType, Packet,
         PacketNumber, PartialDecode, SpaceId,
@@ -2849,7 +2849,7 @@ impl Connection {
                         self.update_rem_cid();
                     }
                 }
-                Frame::NewToken { token } => {
+                Frame::NewToken(NewToken { token }) => {
                     if self.side.is_server() {
                         return Err(TransportError::PROTOCOL_VIOLATION("client sent NEW_TOKEN"));
                     }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -29,7 +29,7 @@ use crate::{
         ConnectionEvent, ConnectionEventInner, ConnectionId, DatagramConnectionEvent, EcnCodepoint,
         EndpointEvent, EndpointEventInner,
     },
-    token::ResetToken,
+    token::{ResetToken, Token, TokenPayload},
     transport_parameters::TransportParameters,
     Dir, Duration, EndpointConfig, Frame, Instant, Side, StreamId, Transmit, TransportError,
     TransportErrorCode, VarInt, INITIAL_MTU, MAX_CID_SIZE, MAX_STREAM_COUNT, MIN_INITIAL_SIZE,
@@ -277,7 +277,7 @@ impl Connection {
                 now,
                 if pref_addr_cid.is_some() { 2 } else { 1 },
             ),
-            path: PathData::new(remote, allow_mtud, None, now, path_validated, &config),
+            path: PathData::new(remote, allow_mtud, None, now, &config),
             allow_mtud,
             local_ip,
             prev_path: None,
@@ -351,6 +351,9 @@ impl Connection {
             stats: ConnectionStats::default(),
             version,
         };
+        if path_validated {
+            this.on_path_validated();
+        }
         if side.is_client() {
             // Kick off the connection
             this.write_crypto();
@@ -2435,7 +2438,7 @@ impl Connection {
                     );
                     return Ok(());
                 }
-                self.path.validated = true;
+                self.on_path_validated();
 
                 self.process_early_payload(now, packet)?;
                 if self.state.is_closed() {
@@ -2965,7 +2968,6 @@ impl Connection {
                 self.allow_mtud,
                 Some(peer_max_udp_payload_size),
                 now,
-                false,
                 &self.config,
             )
         };
@@ -3240,6 +3242,45 @@ impl Connection {
         if self.datagrams.send_blocked && sent_datagrams {
             self.events.push_back(Event::DatagramsUnblocked);
             self.datagrams.send_blocked = false;
+        }
+
+        // NEW_TOKEN
+        while let Some(remote_addr) = space.pending.new_tokens.pop() {
+            debug_assert_eq!(space_id, SpaceId::Data);
+            let ConnectionSide::Server { server_config } = &self.side else {
+                panic!("NEW_TOKEN frames should not be enqueued by clients");
+            };
+
+            if remote_addr != self.path.remote {
+                // NEW_TOKEN frames contain tokens bound to a client's IP address, and are only
+                // useful if used from the same IP address.  Thus, we abandon enqueued NEW_TOKEN
+                // frames upon an path change. Instead, when the new path becomes validated,
+                // NEW_TOKEN frames may be enqueued for the new path instead.
+                continue;
+            }
+
+            let token = Token::new(
+                TokenPayload::Validation {
+                    ip: remote_addr.ip(),
+                    issued: server_config.time_source.now(),
+                },
+                &mut self.rng,
+            );
+            let new_token = NewToken {
+                token: token.encode(&*server_config.token_key).into(),
+            };
+
+            if buf.len() + new_token.size() >= max_size {
+                space.pending.new_tokens.push(remote_addr);
+                break;
+            }
+
+            new_token.encode(buf);
+            sent.retransmits
+                .get_or_create()
+                .new_tokens
+                .push(remote_addr);
+            self.stats.frame_tx.new_token += 1;
         }
 
         // STREAM
@@ -3602,6 +3643,19 @@ impl Connection {
         // this writing, all QUIC cipher suites use 16-byte tags. We could return `None` instead,
         // but that would needlessly prevent sending datagrams during 0-RTT.
         key.map_or(16, |x| x.tag_len())
+    }
+
+    /// Mark the path as validated, and enqueue NEW_TOKEN frames to be sent as appropriate
+    fn on_path_validated(&mut self) {
+        self.path.validated = true;
+        let ConnectionSide::Server { server_config } = &self.side else {
+            return;
+        };
+        let new_tokens = &mut self.spaces[SpaceId::Data as usize].pending.new_tokens;
+        new_tokens.clear();
+        for _ in 0..server_config.validation_token.sent {
+            new_tokens.push(self.path.remote);
+        }
     }
 }
 

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -50,7 +50,6 @@ impl PathData {
         allow_mtud: bool,
         peer_max_udp_payload_size: Option<u16>,
         now: Instant,
-        validated: bool,
         config: &TransportConfig,
     ) -> Self {
         let congestion = config
@@ -70,7 +69,7 @@ impl PathData {
             congestion,
             challenge: None,
             challenge_pending: false,
-            validated,
+            validated: false,
             total_sent: 0,
             total_recvd: 0,
             mtud: config

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -12,7 +12,7 @@ use tracing::trace;
 use super::assembler::Assembler;
 use crate::{
     connection::StreamsState, crypto::Keys, frame, packet::SpaceId, range_set::ArrayRangeSet,
-    shared::IssuedCid, Dir, Duration, Instant, StreamId, TransportError, VarInt,
+    shared::IssuedCid, Dir, Duration, Instant, SocketAddr, StreamId, TransportError, VarInt,
 };
 
 pub(super) struct PacketSpace {
@@ -309,6 +309,23 @@ pub struct Retransmits {
     pub(super) retire_cids: Vec<u64>,
     pub(super) ack_frequency: bool,
     pub(super) handshake_done: bool,
+    /// For each enqueued NEW_TOKEN frame, a copy of the path's remote address
+    ///
+    /// There are 2 reasons this is unusual:
+    ///
+    /// - If the path changes, NEW_TOKEN frames bound for the old path are not retransmitted on the
+    ///   new path. That is why this field stores the remote address: so that ones for old paths
+    ///   can be filtered out.
+    /// - If a token is lost, a new randomly generated token is re-transmitted, rather than the
+    ///   original. This is so that if both transmissions are received, the client won't risk
+    ///   sending the same token twice. That is why this field does _not_ store any actual token.
+    ///
+    /// It is true that a QUIC endpoint will only want to effectively have NEW_TOKEN frames
+    /// enqueued for its current path at a given point in time. Based on that, we could conceivably
+    /// change this from a vector to an `Option<(SocketAddr, usize)>` or just a `usize` or
+    /// something. However, due to the architecture of Quinn, it is considerably simpler to not do
+    /// that; consider what such a change would mean for implementing `BitOrAssign` on Self.
+    pub(super) new_tokens: Vec<SocketAddr>,
 }
 
 impl Retransmits {
@@ -326,6 +343,7 @@ impl Retransmits {
             && self.retire_cids.is_empty()
             && !self.ack_frequency
             && !self.handshake_done
+            && self.new_tokens.is_empty()
     }
 }
 
@@ -347,6 +365,7 @@ impl ::std::ops::BitOrAssign for Retransmits {
         self.retire_cids.extend(rhs.retire_cids);
         self.ack_frequency |= rhs.ack_frequency;
         self.handshake_done |= rhs.handshake_done;
+        self.new_tokens.extend_from_slice(&rhs.new_tokens);
     }
 }
 

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -65,7 +65,7 @@ impl FrameStats {
             Frame::StopSending(_) => self.stop_sending += 1,
             Frame::Crypto(_) => self.crypto += 1,
             Frame::Datagram(_) => self.datagram += 1,
-            Frame::NewToken { .. } => self.new_token += 1,
+            Frame::NewToken(_) => self.new_token += 1,
             Frame::MaxData(_) => self.max_data += 1,
             Frame::MaxStreamData { .. } => self.max_stream_data += 1,
             Frame::MaxStreams { dir, .. } => {

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -364,7 +364,10 @@ impl Endpoint {
             now,
             tls,
             config.transport,
-            SideArgs::Client,
+            SideArgs::Client {
+                token_store: config.token_store,
+                server_name: server_name.into(),
+            },
         );
         Ok((ch, conn))
     }

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -711,9 +711,9 @@ impl Endpoint {
 
     /// Respond with a retry packet, requiring the client to retry with address validation
     ///
-    /// Errors if `incoming.remote_address_validated()` is true.
+    /// Errors if `incoming.may_retry()` is false.
     pub fn retry(&mut self, incoming: Incoming, buf: &mut Vec<u8>) -> Result<Transmit, RetryError> {
-        if incoming.remote_address_validated() {
+        if !incoming.may_retry() {
             return Err(RetryError(incoming));
         }
 
@@ -1172,8 +1172,19 @@ impl Incoming {
     ///
     /// This means that the sender of the initial packet has proved that they can receive traffic
     /// sent to `self.remote_address()`.
+    ///
+    /// If `self.remote_address_validated()` is false, `self.may_retry()` is guaranteed to be true.
+    /// The inverse is not guaranteed.
     pub fn remote_address_validated(&self) -> bool {
-        self.token.retry_src_cid.is_some()
+        self.token.validated
+    }
+
+    /// Whether it is legal to respond with a retry packet
+    ///
+    /// If `self.remote_address_validated()` is false, `self.may_retry()` is guaranteed to be true.
+    /// The inverse is not guaranteed.
+    pub fn may_retry(&self) -> bool {
+        self.token.retry_src_cid.is_none()
     }
 
     /// The original destination connection ID sent by the client

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -29,7 +29,7 @@ use crate::{
         ConnectionEvent, ConnectionEventInner, ConnectionId, DatagramConnectionEvent, EcnCodepoint,
         EndpointEvent, EndpointEventInner, IssuedCid,
     },
-    token::{IncomingToken, InvalidRetryTokenError, RetryToken},
+    token::{IncomingToken, InvalidRetryTokenError, Token},
     transport_parameters::{PreferredAddress, TransportParameters},
     Duration, Instant, ResetToken, Side, Transmit, TransportConfig, TransportError, INITIAL_MTU,
     MAX_CID_SIZE, MIN_INITIAL_SIZE, RESET_TOKEN_SIZE,
@@ -730,7 +730,7 @@ impl Endpoint {
         // retried by the application layer.
         let loc_cid = self.local_cid_generator.generate_cid();
 
-        let token = RetryToken {
+        let token = Token {
             address: incoming.addresses.remote,
             orig_dst_cid: incoming.packet.header.dst_cid,
             issued: server_config.time_source.now(),

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -730,7 +730,7 @@ impl Endpoint {
         // retried by the application layer.
         let loc_cid = self.local_cid_generator.generate_cid();
 
-        let payload = TokenPayload {
+        let payload = TokenPayload::Retry {
             address: incoming.addresses.remote,
             orig_dst_cid: incoming.packet.header.dst_cid,
             issued: server_config.time_source.now(),

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -735,7 +735,7 @@ impl Endpoint {
             orig_dst_cid: incoming.packet.header.dst_cid,
             issued: server_config.time_source.now(),
         };
-        let token = Token::new(payload).encode(&*server_config.token_key, loc_cid);
+        let token = Token::new(payload, &mut self.rng).encode(&*server_config.token_key);
 
         let header = Header::Retry {
             src_cid: loc_cid,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -29,7 +29,7 @@ use crate::{
         ConnectionEvent, ConnectionEventInner, ConnectionId, DatagramConnectionEvent, EcnCodepoint,
         EndpointEvent, EndpointEventInner, IssuedCid,
     },
-    token::{IncomingToken, InvalidRetryTokenError, Token},
+    token::{IncomingToken, InvalidRetryTokenError, Token, TokenPayload},
     transport_parameters::{PreferredAddress, TransportParameters},
     Duration, Instant, ResetToken, Side, Transmit, TransportConfig, TransportError, INITIAL_MTU,
     MAX_CID_SIZE, MIN_INITIAL_SIZE, RESET_TOKEN_SIZE,
@@ -730,12 +730,12 @@ impl Endpoint {
         // retried by the application layer.
         let loc_cid = self.local_cid_generator.generate_cid();
 
-        let token = Token {
+        let payload = TokenPayload {
             address: incoming.addresses.remote,
             orig_dst_cid: incoming.packet.header.dst_cid,
             issued: server_config.time_source.now(),
-        }
-        .encode(&*server_config.token_key, loc_cid);
+        };
+        let token = Token::new(payload).encode(&*server_config.token_key, loc_cid);
 
         let header = Header::Retry {
             src_cid: loc_cid,

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -147,7 +147,7 @@ pub(crate) enum Frame {
     ResetStream(ResetStream),
     StopSending(StopSending),
     Crypto(Crypto),
-    NewToken { token: Bytes },
+    NewToken(NewToken),
     Stream(Stream),
     MaxData(VarInt),
     MaxStreamData { id: StreamId, offset: u64 },
@@ -200,7 +200,7 @@ impl Frame {
             PathResponse(_) => FrameType::PATH_RESPONSE,
             NewConnectionId { .. } => FrameType::NEW_CONNECTION_ID,
             Crypto(_) => FrameType::CRYPTO,
-            NewToken { .. } => FrameType::NEW_TOKEN,
+            NewToken(_) => FrameType::NEW_TOKEN,
             Datagram(_) => FrameType(*DATAGRAM_TYS.start()),
             AckFrequency(_) => FrameType::ACK_FREQUENCY,
             ImmediateAck => FrameType::IMMEDIATE_ACK,
@@ -525,6 +525,11 @@ impl Crypto {
     }
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct NewToken {
+    pub(crate) token: Bytes,
+}
+
 pub(crate) struct Iter {
     bytes: Bytes,
     last_ty: Option<FrameType>,
@@ -671,9 +676,9 @@ impl Iter {
                 offset: self.bytes.get_var()?,
                 data: self.take_len()?,
             }),
-            FrameType::NEW_TOKEN => Frame::NewToken {
+            FrameType::NEW_TOKEN => Frame::NewToken(NewToken {
                 token: self.take_len()?,
-            },
+            }),
             FrameType::HANDSHAKE_DONE => Frame::HandshakeDone,
             FrameType::ACK_FREQUENCY => Frame::AckFrequency(AckFrequency {
                 sequence: self.bytes.get()?,

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -530,6 +530,18 @@ pub(crate) struct NewToken {
     pub(crate) token: Bytes,
 }
 
+impl NewToken {
+    pub(crate) fn encode<W: BufMut>(&self, out: &mut W) {
+        out.write(FrameType::NEW_TOKEN);
+        out.write_var(self.token.len() as u64);
+        out.put_slice(&self.token);
+    }
+
+    pub(crate) fn size(&self) -> usize {
+        1 + VarInt::from_u64(self.token.len() as u64).unwrap().size() + self.token.len()
+    }
+}
+
 pub(crate) struct Iter {
     bytes: Bytes,
     last_ty: Option<FrameType>,

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -86,7 +86,7 @@ pub use crate::cid_generator::{
 
 mod token;
 use token::ResetToken;
-pub use token::{NoneTokenLog, TokenLog, TokenReuseError};
+pub use token::{NoneTokenLog, NoneTokenStore, TokenLog, TokenReuseError, TokenStore};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -51,7 +51,7 @@ pub use rustls;
 mod config;
 pub use config::{
     AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
-    ServerConfig, StdSystemTime, TimeSource, TransportConfig,
+    ServerConfig, StdSystemTime, TimeSource, TransportConfig, ValidationTokenConfig,
 };
 
 pub mod crypto;
@@ -86,6 +86,7 @@ pub use crate::cid_generator::{
 
 mod token;
 use token::ResetToken;
+pub use token::{NoneTokenLog, TokenLog, TokenReuseError};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -35,6 +35,8 @@ use crate::{
 mod util;
 use util::*;
 
+mod token;
+
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -176,24 +178,6 @@ fn draft_version_compat() {
                         ApplicationClose { error_code: VarInt(42), ref reason }
                     )}) if reason == REASON);
     assert_matches!(pair.client_conn_mut(client_ch).poll(), None);
-    assert_eq!(pair.client.known_connections(), 0);
-    assert_eq!(pair.client.known_cids(), 0);
-    assert_eq!(pair.server.known_connections(), 0);
-    assert_eq!(pair.server.known_cids(), 0);
-}
-
-#[test]
-fn stateless_retry() {
-    let _guard = subscribe();
-    let mut pair = Pair::default();
-    pair.server.handle_incoming = Box::new(validate_incoming);
-    let (client_ch, _server_ch) = pair.connect();
-    pair.client
-        .connections
-        .get_mut(&client_ch)
-        .unwrap()
-        .close(pair.time, VarInt(42), Bytes::new());
-    pair.drive();
     assert_eq!(pair.client.known_connections(), 0);
     assert_eq!(pair.client.known_cids(), 0);
     assert_eq!(pair.server.known_connections(), 0);

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2,7 +2,7 @@ use std::{
     convert::TryInto,
     mem,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use assert_matches::assert_matches;

--- a/quinn-proto/src/tests/token.rs
+++ b/quinn-proto/src/tests/token.rs
@@ -1,0 +1,21 @@
+//! Tests specifically for tokens
+
+use super::*;
+
+#[test]
+fn stateless_retry() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    pair.server.handle_incoming = Box::new(validate_incoming);
+    let (client_ch, _server_ch) = pair.connect();
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+}

--- a/quinn-proto/src/tests/token.rs
+++ b/quinn-proto/src/tests/token.rs
@@ -19,3 +19,275 @@ fn stateless_retry() {
     assert_eq!(pair.server.known_connections(), 0);
     assert_eq!(pair.server.known_cids(), 0);
 }
+
+#[test]
+fn use_token() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let client_config = client_config();
+    let (client_ch, _server_ch) = pair.connect_with(client_config.clone());
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+
+    pair.server.handle_incoming = Box::new(|incoming| {
+        assert!(incoming.remote_address_validated());
+        assert!(incoming.may_retry());
+        IncomingConnectionBehavior::Accept
+    });
+    let (client_ch_2, _server_ch_2) = pair.connect_with(client_config);
+    pair.client
+        .connections
+        .get_mut(&client_ch_2)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+}
+
+#[test]
+fn retry_then_use_token() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let client_config = client_config();
+    pair.server.handle_incoming = Box::new(validate_incoming);
+    let (client_ch, _server_ch) = pair.connect_with(client_config.clone());
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+
+    pair.server.handle_incoming = Box::new(|incoming| {
+        assert!(incoming.remote_address_validated());
+        assert!(incoming.may_retry());
+        IncomingConnectionBehavior::Accept
+    });
+    let (client_ch_2, _server_ch_2) = pair.connect_with(client_config);
+    pair.client
+        .connections
+        .get_mut(&client_ch_2)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+}
+
+#[test]
+fn use_token_then_retry() {
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let client_config = client_config();
+    let (client_ch, _server_ch) = pair.connect_with(client_config.clone());
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+
+    pair.server.handle_incoming = Box::new({
+        let mut i = 0;
+        move |incoming| {
+            if i == 0 {
+                assert!(incoming.remote_address_validated());
+                assert!(incoming.may_retry());
+                i += 1;
+                IncomingConnectionBehavior::Retry
+            } else if i == 1 {
+                assert!(incoming.remote_address_validated());
+                assert!(!incoming.may_retry());
+                i += 1;
+                IncomingConnectionBehavior::Accept
+            } else {
+                panic!("too many handle_incoming iterations")
+            }
+        }
+    });
+    let (client_ch_2, _server_ch_2) = pair.connect_with(client_config);
+    pair.client
+        .connections
+        .get_mut(&client_ch_2)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+}
+
+#[test]
+fn use_same_token_twice() {
+    #[derive(Default)]
+    struct EvilTokenStore(Mutex<Bytes>);
+
+    impl TokenStore for EvilTokenStore {
+        fn insert(&self, _server_name: &str, token: Bytes) {
+            let mut lock = self.0.lock().unwrap();
+            if lock.is_empty() {
+                *lock = token;
+            }
+        }
+
+        fn take(&self, _server_name: &str) -> Option<Bytes> {
+            let lock = self.0.lock().unwrap();
+            if lock.is_empty() {
+                None
+            } else {
+                Some(lock.clone())
+            }
+        }
+    }
+
+    let _guard = subscribe();
+    let mut pair = Pair::default();
+    let mut client_config = client_config();
+    client_config.token_store(Arc::new(EvilTokenStore::default()));
+    let (client_ch, _server_ch) = pair.connect_with(client_config.clone());
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+
+    pair.server.handle_incoming = Box::new(|incoming| {
+        assert!(incoming.remote_address_validated());
+        assert!(incoming.may_retry());
+        IncomingConnectionBehavior::Accept
+    });
+    let (client_ch_2, _server_ch_2) = pair.connect_with(client_config.clone());
+    pair.client
+        .connections
+        .get_mut(&client_ch_2)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+
+    pair.server.handle_incoming = Box::new(|incoming| {
+        assert!(!incoming.remote_address_validated());
+        assert!(incoming.may_retry());
+        IncomingConnectionBehavior::Accept
+    });
+    let (client_ch_3, _server_ch_3) = pair.connect_with(client_config);
+    pair.client
+        .connections
+        .get_mut(&client_ch_3)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+}
+
+#[test]
+fn use_token_expired() {
+    let _guard = subscribe();
+    let fake_time = Arc::new(FakeTimeSource::new());
+    let lifetime = Duration::from_secs(10000);
+    let mut server_config = server_config();
+    server_config
+        .time_source(Arc::clone(&fake_time) as _)
+        .validation_token
+        .lifetime(lifetime);
+    let mut pair = Pair::new(Default::default(), server_config);
+    let client_config = client_config();
+    let (client_ch, _server_ch) = pair.connect_with(client_config.clone());
+    pair.client
+        .connections
+        .get_mut(&client_ch)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+
+    pair.server.handle_incoming = Box::new(|incoming| {
+        assert!(incoming.remote_address_validated());
+        assert!(incoming.may_retry());
+        IncomingConnectionBehavior::Accept
+    });
+    let (client_ch_2, _server_ch_2) = pair.connect_with(client_config.clone());
+    pair.client
+        .connections
+        .get_mut(&client_ch_2)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+
+    fake_time.advance(lifetime + Duration::from_secs(1));
+
+    pair.server.handle_incoming = Box::new(|incoming| {
+        assert!(!incoming.remote_address_validated());
+        assert!(incoming.may_retry());
+        IncomingConnectionBehavior::Accept
+    });
+    let (client_ch_3, _server_ch_3) = pair.connect_with(client_config);
+    pair.client
+        .connections
+        .get_mut(&client_ch_3)
+        .unwrap()
+        .close(pair.time, VarInt(42), Bytes::new());
+    pair.drive();
+    assert_eq!(pair.client.known_connections(), 0);
+    assert_eq!(pair.client.known_cids(), 0);
+    assert_eq!(pair.server.known_connections(), 0);
+    assert_eq!(pair.server.known_cids(), 0);
+}
+
+pub(super) struct FakeTimeSource(Mutex<SystemTime>);
+
+impl FakeTimeSource {
+    pub(super) fn new() -> Self {
+        Self(Mutex::new(SystemTime::now()))
+    }
+
+    pub(super) fn advance(&self, dur: Duration) {
+        *self.0.lock().unwrap() += dur;
+    }
+}
+
+impl TimeSource for FakeTimeSource {
+    fn now(&self) -> SystemTime {
+        *self.0.lock().unwrap()
+    }
+}

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -20,6 +20,7 @@ use crate::{
 pub(crate) struct IncomingToken {
     pub(crate) retry_src_cid: Option<ConnectionId>,
     pub(crate) orig_dst_cid: ConnectionId,
+    pub(crate) validated: bool,
 }
 
 impl IncomingToken {
@@ -33,6 +34,7 @@ impl IncomingToken {
         let unvalidated = Self {
             retry_src_cid: None,
             orig_dst_cid: header.dst_cid,
+            validated: false,
         };
 
         // Decode token or short-circuit
@@ -67,6 +69,7 @@ impl IncomingToken {
         Ok(Self {
             retry_src_cid: Some(header.dst_cid),
             orig_dst_cid: retry.payload.orig_dst_cid,
+            validated: true,
         })
     }
 }

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -55,22 +55,27 @@ impl IncomingToken {
             return Ok(unvalidated);
         };
 
-        // Validate token
-        if retry.payload.address != remote_address {
-            return Err(InvalidRetryTokenError);
-        }
-        if retry.payload.issued + server_config.retry_token_lifetime
-            < server_config.time_source.now()
-        {
-            return Err(InvalidRetryTokenError);
-        }
+        // Validate token, then convert into Self
+        match retry.payload {
+            TokenPayload::Retry {
+                address,
+                orig_dst_cid,
+                issued,
+            } => {
+                if address != remote_address {
+                    return Err(InvalidRetryTokenError);
+                }
+                if issued + server_config.retry_token_lifetime < server_config.time_source.now() {
+                    return Err(InvalidRetryTokenError);
+                }
 
-        // Convert token into Self
-        Ok(Self {
-            retry_src_cid: Some(header.dst_cid),
-            orig_dst_cid: retry.payload.orig_dst_cid,
-            validated: true,
-        })
+                Ok(Self {
+                    retry_src_cid: Some(header.dst_cid),
+                    orig_dst_cid,
+                    validated: true,
+                })
+            }
+        }
     }
 }
 
@@ -101,9 +106,18 @@ impl Token {
         let mut buf = Vec::new();
 
         // Encode payload
-        encode_addr(&mut buf, self.payload.address);
-        self.payload.orig_dst_cid.encode_long(&mut buf);
-        encode_unix_secs(&mut buf, self.payload.issued);
+        match self.payload {
+            TokenPayload::Retry {
+                address,
+                orig_dst_cid,
+                issued,
+            } => {
+                buf.put_u8(TokenType::Retry as u8);
+                encode_addr(&mut buf, address);
+                orig_dst_cid.encode_long(&mut buf);
+                encode_unix_secs(&mut buf, issued);
+            }
+        }
 
         // Encrypt
         let aead_key = key.aead_from_hkdf(&self.nonce.to_le_bytes());
@@ -129,34 +143,48 @@ impl Token {
 
         // Decode payload
         let mut reader = &data[..];
-        let address = decode_addr(&mut reader)?;
-        let orig_dst_cid = ConnectionId::decode_long(&mut reader)?;
-        let issued = decode_unix_secs(&mut reader)?;
+        let payload = match TokenType::from_byte((&mut reader).get::<u8>().ok()?)? {
+            TokenType::Retry => TokenPayload::Retry {
+                address: decode_addr(&mut reader)?,
+                orig_dst_cid: ConnectionId::decode_long(&mut reader)?,
+                issued: decode_unix_secs(&mut reader)?,
+            },
+        };
 
         if !reader.is_empty() {
             // Consider extra bytes a decoding error (it may be from an incompatible endpoint)
             return None;
         }
 
-        Some(Self {
-            nonce,
-            payload: TokenPayload {
-                address,
-                orig_dst_cid,
-                issued,
-            },
-        })
+        Some(Self { nonce, payload })
     }
 }
 
 /// Content of a [`Token`] that is encrypted from the client
-pub(crate) struct TokenPayload {
-    /// The client's address
-    pub(crate) address: SocketAddr,
-    /// The destination connection ID set in the very first packet from the client
-    pub(crate) orig_dst_cid: ConnectionId,
-    /// The time at which this token was issued
-    pub(crate) issued: SystemTime,
+pub(crate) enum TokenPayload {
+    /// Token originating from a Retry packet
+    Retry {
+        /// The client's address
+        address: SocketAddr,
+        /// The destination connection ID set in the very first packet from the client
+        orig_dst_cid: ConnectionId,
+        /// The time at which this token was issued
+        issued: SystemTime,
+    },
+}
+
+/// Variant tag for a [`TokenPayload`]
+#[derive(Copy, Clone)]
+#[repr(u8)]
+enum TokenType {
+    Retry = 0,
+}
+
+impl TokenType {
+    fn from_byte(n: u8) -> Option<Self> {
+        use TokenType::*;
+        [Retry].into_iter().find(|ty| *ty as u8 == n)
+    }
 }
 
 fn encode_addr(buf: &mut Vec<u8>, address: SocketAddr) {
@@ -253,43 +281,54 @@ impl fmt::Display for ResetToken {
 
 #[cfg(all(test, any(feature = "aws-lc-rs", feature = "ring")))]
 mod test {
+    use super::*;
     #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
     use aws_lc_rs::hkdf;
+    use rand::prelude::*;
     #[cfg(feature = "ring")]
     use ring::hkdf;
 
+    fn token_round_trip(payload: TokenPayload) -> TokenPayload {
+        let rng = &mut rand::thread_rng();
+        let token = Token::new(payload, rng);
+        let mut master_key = [0; 64];
+        rng.fill_bytes(&mut master_key);
+        let prk = hkdf::Salt::new(hkdf::HKDF_SHA256, &[]).extract(&master_key);
+        let encoded = token.encode(&prk);
+        let decoded = Token::decode(&prk, &encoded).expect("token didn't decrypt / decode");
+        assert_eq!(token.nonce, decoded.nonce);
+        decoded.payload
+    }
+
     #[test]
-    fn token_sanity() {
-        use super::*;
+    fn retry_token_sanity() {
         use crate::cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator};
         use crate::MAX_CID_SIZE;
         use crate::{Duration, UNIX_EPOCH};
 
-        use rand::RngCore;
         use std::net::Ipv6Addr;
 
-        let rng = &mut rand::thread_rng();
-
-        let mut master_key = [0; 64];
-        rng.fill_bytes(&mut master_key);
-
-        let prk = hkdf::Salt::new(hkdf::HKDF_SHA256, &[]).extract(&master_key);
-
-        let address = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 4433);
-        let token = Token {
-            nonce: rng.gen(),
-            payload: TokenPayload {
-                address,
-                orig_dst_cid: RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid(),
-                issued: UNIX_EPOCH + Duration::from_secs(42), // Fractional seconds would be lost
-            },
+        let address_1 = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 4433);
+        let orig_dst_cid_1 = RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid();
+        let issued_1 = UNIX_EPOCH + Duration::from_secs(42); // Fractional seconds would be lost
+        let payload_1 = TokenPayload::Retry {
+            address: address_1,
+            orig_dst_cid: orig_dst_cid_1,
+            issued: issued_1,
         };
-        let encoded = token.encode(&prk);
+        #[allow(irrefutable_let_patterns)] // TEMPORARY until next commit
+        let TokenPayload::Retry {
+            address: address_2,
+            orig_dst_cid: orig_dst_cid_2,
+            issued: issued_2,
+        } = token_round_trip(payload_1)
+        else {
+            panic!("token decoded as wrong variant");
+        };
 
-        let decoded = Token::decode(&prk, &encoded).expect("token didn't validate");
-        assert_eq!(token.payload.address, decoded.payload.address);
-        assert_eq!(token.payload.orig_dst_cid, decoded.payload.orig_dst_cid);
-        assert_eq!(token.payload.issued, decoded.payload.issued);
+        assert_eq!(address_1, address_2);
+        assert_eq!(orig_dst_cid_1, orig_dst_cid_2);
+        assert_eq!(issued_1, issued_2);
     }
 
     #[test]

--- a/quinn-proto/src/token.rs
+++ b/quinn-proto/src/token.rs
@@ -15,6 +15,66 @@ use crate::{
     Duration, ServerConfig, SystemTime, RESET_TOKEN_SIZE, UNIX_EPOCH,
 };
 
+/// Responsible for limiting clients' ability to reuse validation tokens
+///
+/// [_RFC 9000 § 8.1.4:_](https://www.rfc-editor.org/rfc/rfc9000.html#section-8.1.4)
+///
+/// > Attackers could replay tokens to use servers as amplifiers in DDoS attacks. To protect
+/// > against such attacks, servers MUST ensure that replay of tokens is prevented or limited.
+/// > Servers SHOULD ensure that tokens sent in Retry packets are only accepted for a short time,
+/// > as they are returned immediately by clients. Tokens that are provided in NEW_TOKEN frames
+/// > (Section 19.7) need to be valid for longer but SHOULD NOT be accepted multiple times.
+/// > Servers are encouraged to allow tokens to be used only once, if possible; tokens MAY include
+/// > additional information about clients to further narrow applicability or reuse.
+///
+/// `TokenLog` pertains only to tokens provided in NEW_TOKEN frames.
+pub trait TokenLog: Send + Sync {
+    /// Record that the token was used and, ideally, return a token reuse error if the token may
+    /// have been already used previously
+    ///
+    /// False negatives and false positives are both permissible. Called when a client uses an
+    /// address validation token.
+    ///
+    /// Parameters:
+    /// - `nonce`: A server-generated random unique value for the token.
+    /// - `issued`: The time the server issued the token.
+    /// - `lifetime`: The expiration time of address validation tokens sent via NEW_TOKEN frames,
+    ///   as configured by [`ServerValidationTokenConfig::lifetime`][1].
+    ///
+    /// [1]: crate::ValidationTokenConfig::lifetime
+    ///
+    /// ## Security & Performance
+    ///
+    /// To the extent that it is possible to repeatedly trigger false negatives (returning `Ok` for
+    /// a token which has been reused), an attacker could use the server to perform [amplification
+    /// attacks][2]. The QUIC specification requires that this be limited, if not prevented fully.
+    ///
+    /// A false positive (returning `Err` for a token which has never been used) is not a security
+    /// vulnerability; it is permissible for a `TokenLog` to always return `Err`. A false positive
+    /// causes the token to be ignored, which may cause the transmission of some 0.5-RTT data to be
+    /// delayed until the handshake completes, if a sufficient amount of 0.5-RTT data it sent.
+    ///
+    /// [2]: https://en.wikipedia.org/wiki/Denial-of-service_attack#Amplification
+    fn check_and_insert(
+        &self,
+        nonce: u128,
+        issued: SystemTime,
+        lifetime: Duration,
+    ) -> Result<(), TokenReuseError>;
+}
+
+/// Error for when a validation token may have been reused
+pub struct TokenReuseError;
+
+/// Null implementation of [`TokenLog`], which never accepts tokens
+pub struct NoneTokenLog;
+
+impl TokenLog for NoneTokenLog {
+    fn check_and_insert(&self, _: u128, _: SystemTime, _: Duration) -> Result<(), TokenReuseError> {
+        Err(TokenReuseError)
+    }
+}
+
 /// State in an `Incoming` determined by a token or lack thereof
 #[derive(Debug)]
 pub(crate) struct IncomingToken {
@@ -75,6 +135,30 @@ impl IncomingToken {
                     validated: true,
                 })
             }
+            TokenPayload::Validation { ip, issued } => {
+                if ip != remote_address.ip() {
+                    return Ok(unvalidated);
+                }
+                if issued + server_config.validation_token.lifetime
+                    < server_config.time_source.now()
+                {
+                    return Ok(unvalidated);
+                }
+                if server_config
+                    .validation_token
+                    .log
+                    .check_and_insert(retry.nonce, issued, server_config.validation_token.lifetime)
+                    .is_err()
+                {
+                    return Ok(unvalidated);
+                }
+
+                Ok(Self {
+                    retry_src_cid: None,
+                    orig_dst_cid: header.dst_cid,
+                    validated: true,
+                })
+            }
         }
     }
 }
@@ -117,6 +201,11 @@ impl Token {
                 orig_dst_cid.encode_long(&mut buf);
                 encode_unix_secs(&mut buf, issued);
             }
+            TokenPayload::Validation { ip, issued } => {
+                buf.put_u8(TokenType::Validation as u8);
+                encode_ip(&mut buf, ip);
+                encode_unix_secs(&mut buf, issued);
+            }
         }
 
         // Encrypt
@@ -149,6 +238,10 @@ impl Token {
                 orig_dst_cid: ConnectionId::decode_long(&mut reader)?,
                 issued: decode_unix_secs(&mut reader)?,
             },
+            TokenType::Validation => TokenPayload::Validation {
+                ip: decode_ip(&mut reader)?,
+                issued: decode_unix_secs(&mut reader)?,
+            },
         };
 
         if !reader.is_empty() {
@@ -171,6 +264,13 @@ pub(crate) enum TokenPayload {
         /// The time at which this token was issued
         issued: SystemTime,
     },
+    /// Token originating from a NEW_TOKEN frame
+    Validation {
+        /// The client's IP address (its port is likely to change between sessions)
+        ip: IpAddr,
+        /// The time at which this token was issued
+        issued: SystemTime,
+    },
 }
 
 /// Variant tag for a [`TokenPayload`]
@@ -178,12 +278,13 @@ pub(crate) enum TokenPayload {
 #[repr(u8)]
 enum TokenType {
     Retry = 0,
+    Validation = 1,
 }
 
 impl TokenType {
     fn from_byte(n: u8) -> Option<Self> {
         use TokenType::*;
-        [Retry].into_iter().find(|ty| *ty as u8 == n)
+        [Retry, Validation].into_iter().find(|ty| *ty as u8 == n)
     }
 }
 
@@ -316,7 +417,6 @@ mod test {
             orig_dst_cid: orig_dst_cid_1,
             issued: issued_1,
         };
-        #[allow(irrefutable_let_patterns)] // TEMPORARY until next commit
         let TokenPayload::Retry {
             address: address_2,
             orig_dst_cid: orig_dst_cid_2,
@@ -328,6 +428,31 @@ mod test {
 
         assert_eq!(address_1, address_2);
         assert_eq!(orig_dst_cid_1, orig_dst_cid_2);
+        assert_eq!(issued_1, issued_2);
+    }
+
+    #[test]
+    fn validation_token_sanity() {
+        use crate::{Duration, UNIX_EPOCH};
+
+        use std::net::Ipv6Addr;
+
+        let ip_1 = Ipv6Addr::LOCALHOST.into();
+        let issued_1 = UNIX_EPOCH + Duration::from_secs(42); // Fractional seconds would be lost
+
+        let payload_1 = TokenPayload::Validation {
+            ip: ip_1,
+            issued: issued_1,
+        };
+        let TokenPayload::Validation {
+            ip: ip_2,
+            issued: issued_2,
+        } = token_round_trip(payload_1)
+        else {
+            panic!("token decoded as wrong variant");
+        };
+
+        assert_eq!(ip_1, ip_2);
         assert_eq!(issued_1, issued_2);
     }
 

--- a/quinn/src/incoming.rs
+++ b/quinn/src/incoming.rs
@@ -48,7 +48,7 @@ impl Incoming {
 
     /// Respond with a retry packet, requiring the client to retry with address validation
     ///
-    /// Errors if `remote_address_validated()` is true.
+    /// Errors if `may_retry()` is false.
     pub fn retry(mut self) -> Result<(), RetryError> {
         let state = self.0.take().unwrap();
         state.endpoint.retry(state.inner).map_err(|e| {
@@ -79,8 +79,19 @@ impl Incoming {
     ///
     /// This means that the sender of the initial packet has proved that they can receive traffic
     /// sent to `self.remote_address()`.
+    ///
+    /// If `self.remote_address_validated()` is false, `self.may_retry()` is guaranteed to be true.
+    /// The inverse is not guaranteed.
     pub fn remote_address_validated(&self) -> bool {
         self.0.as_ref().unwrap().inner.remote_address_validated()
+    }
+
+    /// Whether it is legal to respond with a retry packet
+    ///
+    /// If `self.remote_address_validated()` is false, `self.may_retry()` is guaranteed to be true.
+    /// The inverse is not guaranteed.
+    pub fn may_retry(&self) -> bool {
+        self.0.as_ref().unwrap().inner.may_retry()
     }
 
     /// The original destination CID when initiating the connection

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -70,9 +70,9 @@ pub use proto::{
     congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream,
     ConfigError, ConnectError, ConnectionClose, ConnectionError, ConnectionId,
     ConnectionIdGenerator, ConnectionStats, Dir, EcnCodepoint, EndpointConfig, FrameStats,
-    FrameType, IdleTimeout, MtuDiscoveryConfig, PathStats, ServerConfig, Side, StdSystemTime,
-    StreamId, TimeSource, Transmit, TransportConfig, TransportErrorCode, UdpStats, VarInt,
-    VarIntBoundsExceeded, Written,
+    FrameType, IdleTimeout, MtuDiscoveryConfig, NoneTokenLog, PathStats, ServerConfig, Side,
+    StdSystemTime, StreamId, TimeSource, TokenLog, TokenReuseError, Transmit, TransportConfig,
+    TransportErrorCode, UdpStats, ValidationTokenConfig, VarInt, VarIntBoundsExceeded, Written,
 };
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
 pub use rustls;

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -70,9 +70,10 @@ pub use proto::{
     congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream,
     ConfigError, ConnectError, ConnectionClose, ConnectionError, ConnectionId,
     ConnectionIdGenerator, ConnectionStats, Dir, EcnCodepoint, EndpointConfig, FrameStats,
-    FrameType, IdleTimeout, MtuDiscoveryConfig, NoneTokenLog, PathStats, ServerConfig, Side,
-    StdSystemTime, StreamId, TimeSource, TokenLog, TokenReuseError, Transmit, TransportConfig,
-    TransportErrorCode, UdpStats, ValidationTokenConfig, VarInt, VarIntBoundsExceeded, Written,
+    FrameType, IdleTimeout, MtuDiscoveryConfig, NoneTokenLog, NoneTokenStore, PathStats,
+    ServerConfig, Side, StdSystemTime, StreamId, TimeSource, TokenLog, TokenReuseError, TokenStore,
+    Transmit, TransportConfig, TransportErrorCode, UdpStats, ValidationTokenConfig, VarInt,
+    VarIntBoundsExceeded, Written,
 };
 #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
 pub use rustls;


### PR DESCRIPTION
Key points:

- Token generalized to have both a "retry token" variant and a "new token frame token" variant
  - Additional byte acts as discriminant. It is not encrypted, but rather considered the "additional data" of the token's AEAD encryption. Other than that, the "retry token" variant remains the same.
  - The `NewToken` variant's `aead_from_hkdf` key derivation is based on an empty byte slice `&[]` rather than the `retry_src_cid`.
  - The `NewToken` variant's encrypted data consists of: randomly generated 128 bits, IP address (not including port), issued timestamp.
- Server sends client 2 NEW_TOKEN frames whenever client's path is validated (reconfigurable through `ServerConfig.new_tokens_sent_upon_validation`)
- `ClientConfig.new_token_store: Option<Arc<dyn NewTokenStore>>` object stores NEW_TOKEN tokens received by client, and dispenses them for one-time use when connecting to same `server_name` again
  - Default implementation `InMemNewTokenStore` stores 2 newest unused tokens for up to 256 servers with LRU eviction policy of server names, so as to pair well with [`rustls::client::ClientSessionMemoryCache`](https://docs.rs/rustls/latest/rustls/client/struct.ClientSessionMemoryCache.html)
- `ServerConfig.token_reuse_preventer: Option<Arc<Mutex<Box<dyn TokenReusePreventer>>>>` object is responsible for mitigating reuse of NEW_TOKEN tokens
  - Default implementation `BloomTokenReusePreventer`:
    
    Divides all time into periods of length `new_token_lifetime` starting at unix epoch. Always maintains two "filters" which track used tokens which expires in that period. Turning over filters as time passes prevents infinite accumulation of tracked tokens.
    
    Filters start out as FxHashSets. This achieves the desirable property of linear-ish memory usage: if few NEW_TOKEN tokens are actually being used, the server's bloom token reuse preventer uses negligible memory.
    
    Once a hash set filter would exceed a configurable maximum memory consumption, it's converted to a bloom filter. This achieves the property that an upper bound is set on the number of bytes allocated by the reuse preventer. Instead, as more tokens are added to the bloom filter, the false positive rate (tokens not actually reused but considered to be reused and thus ignored anyways) increases.
- `ServerConfig.new_token_lifetime` is different from `ServerConfig.retry_token_lifetime` and defaults to 2 weeks.

TODO:

- [x] Send when validated rather than upon first connecting
- [x] Send upon path change
- [ ] Update stats
- [ ] Tests
- [x] Reuse prevention
  - [x] Simplify it--it's not even used concurrently
- [ ] Make sure encryption is good
- [x] Make not break if receive Retry in response to request with NEW_TOKEN token
- [x] NEW_TOKEN tokens should not encode the port (?)
- [ ] We don't need a top-level Token.encode